### PR TITLE
fix(stale): never auto-close — label only (days-before-close: -1)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
           stale-issue-message: |
             👋 This issue has been automatically marked as stale because it has not had recent activity.
 
-            It will be closed in 14 days if no further activity occurs.
+            It will remain open — this label is informational only; this project never auto-closes.
 
             If this issue is still relevant, please:
             - Add a comment to keep it open
@@ -36,7 +36,7 @@ jobs:
 
             If you believe this issue is still relevant, please reopen it and provide updated information.
           days-before-stale: 60
-          days-before-close: 14
+          days-before-close: -1
           stale-issue-label: 'stale'
           close-issue-label: 'auto-closed'
           exempt-issue-labels: 'keep-open,pinned,security,roadmap,in-progress'
@@ -45,7 +45,7 @@ jobs:
           stale-pr-message: |
             👋 This pull request has been automatically marked as stale because it has not had recent activity.
 
-            It will be closed in 7 days if no further activity occurs.
+            It will remain open — this label is informational only; this project never auto-closes.
 
             If this PR is still being worked on, please:
             - Add a comment with an update
@@ -59,7 +59,7 @@ jobs:
 
             If you'd like to continue working on this, please reopen it or create a new PR.
           days-before-pr-stale: 30
-          days-before-pr-close: 7
+          days-before-pr-close: -1
           stale-pr-label: 'stale'
           close-pr-label: 'auto-closed'
           exempt-pr-labels: 'keep-open,in-review,wip,blocked'


### PR DESCRIPTION
The stale workflow auto-closed issues/PRs, violating this universe's absolute doctrine: **we never close, dismiss, or delete** — *if it was ever asked for it was wanted*.

This sets the close window to `-1` (`actions/stale` never-close), preserving the informational `stale` label but never closing. Surgical, reversible, single-file.